### PR TITLE
Prevent setState from being called on unmounted component

### DIFF
--- a/lib/SGListViewCell.js
+++ b/lib/SGListViewCell.js
@@ -31,8 +31,12 @@ var SGListViewCell = React.createClass({
       width: 0, // the view defaults to width of size 0
       height: 0, // the view defaults to height of size 0
     };
+    this.rendered = true;
   },
-
+  
+  componentWillUnmount() {
+    this.rendered = false;
+  },
   /**
    * Render Methods
    */
@@ -60,14 +64,16 @@ var SGListViewCell = React.createClass({
    * View Management Methods
    */
   setVisibility(visibility) {
-    if (this.state.visibility == visibility) {
-      return; // already have the passed in state, so return early
-    }
-
-    if (visibility == true) {
-      this.setState({visibility: true});
-    } else {
-      this.setState({visibility: false});
+    if (this.rendered) {
+      if (this.state.visibility == visibility) {
+        return; // already have the passed in state, so return early
+      }
+  
+      if (visibility == true) {
+        this.setState({visibility: true});
+      } else {
+        this.setState({visibility: false});
+      }
     }
   },
 });


### PR DESCRIPTION
Added this.rendered to make sure that setState is not called when a component has been unmounted. Ran into this issue when filtering against the datasource and started receiving warnings during scroll if filter was reset to initial dataset.
